### PR TITLE
fix developers secondary graph size  + scrollable

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@
                             <!--Global Evolution of the developer part-->
                             <div class= "rightPartTop3PartContent">
                                 <!--Graph Developer's part that present a circle packing chart of developers-->
-                                <div id="developer_circle_packing_chart_2" style="align-self: center;"></div>
+                                <div id="developer_circle_packing_chart_2" style="align-self: center; height: 100%; width: 100%;"></div>
                             </div>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -414,6 +414,7 @@
         navigation: true, // Adds navigation dots
         navigationTooltips: ['Home', 'Introduction', 'Genre trends', 'Platforms', 'Developers', 'Interactive diagram', 'Conclusion', 'About us'], // Adds name to navigation dots
         sectionsColor: ['#000000', '', '', '', '', '', '', '#FFFFFF'], // Background colors for each section
+        normalScrollElements: ".rightPartDescriptionPart, .podiumGame, .gameCard, .rightPartListContainer", // to avoid going to another page when scrolling
         });
     </script>
     <!--Introduction dynamic statistics displaying-->


### PR DESCRIPTION
fix 1:

fix the size of the secondary graphs on windows with large width and smaller height.

before
![image](https://github.com/com-480-data-visualization/project-2024-VizLeGame/assets/61149724/13b4b8d2-fc2d-4e2b-ab14-5d781a18dcda)

after
![image](https://github.com/com-480-data-visualization/project-2024-VizLeGame/assets/61149724/9ab8813c-7250-4c62-8f2c-cb93eb5335f7)

fix2:

fix the scrollable. Small issue, this will also happen when there is no overflow (height/width too big so scrollbar appears). For example, if the gamecards are fully displayed with no scrollbars but the user tries to scroll with the mouse on the gamecards it will do nothing.
